### PR TITLE
Hide unlocked bootloader status from safetynet

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char new_command_line[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", new_command_line);
 	return 0;
 }
 
@@ -23,6 +26,29 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+	char *offset_addr, *cmd = new_command_line;
+
+	strcpy(cmd, saved_command_line);
+
+	/*
+	 * Remove 'androidboot.verifiedbootstate' flag from command line seen
+	 * by userspace in order to pass SafetyNet CTS check.
+	 */
+	offset_addr = strstr(cmd, "androidboot.verifiedbootstate=");
+	if (offset_addr) {
+		size_t i, len, offset;
+
+		len = strlen(cmd);
+		offset = offset_addr - cmd;
+
+		for (i = 1; i < (len - offset); i++) {
+			if (cmd[offset + i] == ' ')
+				break;
+		}
+
+		memmove(offset_addr, &cmd[offset + i + 1], len - i - offset);
+	}
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
From: https://github.com/sultanxda/android_kernel_oneplus_msm8996/commit/abc05b16bbd33521c2fffaf491c5657a94bfcfc5

More info:
https://www.xda-developers.com/sultanxda-bypasses-new-safetynet-unlocked-bootloader-check-on-latest-cm13-builds-for-op3/

proc: Remove verifiedbootstate flag from /proc/cmdline

Userspace parses this and sets the ro.boot.verifiedbootstate prop
according to the value that this flag has. When ro.boot.verifiedbootstate
is not 'green', SafetyNet is tripped and fails the CTS test.

Hide verifiedbootstate from /proc/cmdline in order to fix the failed
SafetyNet CTS check.

Signed-off-by: Sultanxda <sultanxda@gmail.com>
Signed-off-by: Andrew Leech <andrew@alelec.net>